### PR TITLE
Fixing Carbon Calculations

### DIFF
--- a/ml_eval_pro/auto_evaluator.py
+++ b/ml_eval_pro/auto_evaluator.py
@@ -117,9 +117,9 @@ class AutoEvaluator:
         carbon_emission_predictions_per_kg_co = carbon_emission_calc.calculate_predictions()
 
         return {
-            'inference_time_val': inference_time_val,
+            'inference_time_val': float(inference_time_val),
             'inference_time_summary': InferenceSummary(inference_time).get_summary(),
-            'carbon_per_prediction': carbon_emission_carbon_per_prediction,
+            'carbon_per_prediction': float(carbon_emission_carbon_per_prediction),
             'carbon_prediction_per_kg': carbon_emission_predictions_per_kg_co,
             'carbon_summary': CarbonSummary(carbon_emission).get_summary()
         }

--- a/ml_eval_pro/carbon/carbon_emission/carbon_calculator.py
+++ b/ml_eval_pro/carbon/carbon_emission/carbon_calculator.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from ml_eval_pro.carbon.carbon_emission.carbon import Carbon
 
 
@@ -25,7 +27,9 @@ class CarbonCalculator:
         - float: carbon emissions per prediction.
 
         """
-        carbon_per_prediction = self.carbon.energy_generator_value * self.carbon.cpu_value * self.carbon.inference_time
+        print(self.carbon.inference_time)
+        carbon_per_prediction = (Decimal(self.carbon.energy_generator_value) *
+                                 Decimal(self.carbon.cpu_value) * self.carbon.inference_time)
         return carbon_per_prediction
 
     def calculate_predictions(self):
@@ -39,6 +43,5 @@ class CarbonCalculator:
         try:
             predictions_needed = 1 / self.calculate_carbon()
             return round(predictions_needed)
-        except ZeroDivisionError as e:
+        except ZeroDivisionError:
             return 0
-

--- a/ml_eval_pro/carbon/inference_time/inference_time.py
+++ b/ml_eval_pro/carbon/inference_time/inference_time.py
@@ -1,5 +1,6 @@
 import time
 from decimal import getcontext
+from decimal import Decimal
 
 
 class InferenceTime:
@@ -28,12 +29,19 @@ class InferenceTime:
         - float: inference time in seconds.
 
         """
-        start_time = time.time()
+        getcontext().prec = 20
+
+        start_time = time.perf_counter_ns()
         self.model.predict(self.data)
-        end_time = time.time()
-        getcontext().prec = 10
-        seconds = (end_time - start_time) / len(self.data)
-        return seconds
+        end_time = time.perf_counter_ns()
+
+        sec = Decimal(end_time - start_time) / Decimal(1e9)
+
+        if sec > 0:
+            seconds = Decimal(sec) / Decimal(len(self.data))
+            return seconds
+        else:
+            return -1
 
     def calc_inference_time_hours(self):
         """
@@ -43,8 +51,8 @@ class InferenceTime:
         - float: inference time in hours.
 
         """
-        getcontext().prec = 10
-        hours = self.calc_inference_time_seconds() / 3600
+        getcontext().prec = 20
+        hours = self.calc_inference_time_seconds() / Decimal(3600)
         return hours
 
     def calc_inference_time_minutes(self):
@@ -55,8 +63,8 @@ class InferenceTime:
         - float: inference time in minutes.
 
         """
-        getcontext().prec = 10
-        minutes = self.calc_inference_time_seconds() / 60
+        getcontext().prec = 20
+        minutes = Decimal(self.calc_inference_time_seconds() / Decimal(60))
         return minutes
 
     def __str__(self):
@@ -64,5 +72,5 @@ class InferenceTime:
         Return:
         - str: a string of the inference time.
         """
-        msg = (f'The model average inference time per instance is {str(self.calc_inference_time_seconds())} seconds')
+        msg = f'The model average inference time per instance is {self.calc_inference_time_seconds():.10f} seconds'
         return msg


### PR DESCRIPTION
Using time.perf_counter_ns() instead of time.time()

More accurate for measuring short durations accurately.